### PR TITLE
Out of bounds reads

### DIFF
--- a/linearalgebra.h
+++ b/linearalgebra.h
@@ -280,9 +280,13 @@ double partialdot_product (double * x, double * y, int length, int index) {
     int i, length5;
     double sum = 0;
 
+    length -= index;
+    x += index;
+    y += index;
+
     length5 = length % 5;
 
-    for(i = index; i < length5; i++) {
+    for(i = 0; i < length5; i++) {
         sum += x[i] * y[i];
     }
     for(; i < length; i += 5) {


### PR DESCRIPTION
Hi,

I needed a bare bones QR and your code came in handy. Going though it, I realized that it had an out of bounds error in partialdot_product() which I have fixed in this PR. Interestingly, this error does not seem to affect the computed factorization.

If called with length=10 and index=1, the original code will access vector elements at indices
1 2 3 4 5 6 7 8 9 10   (all in the 2nd loop)
Note that the last one (10) is out of bounds.

Similarly, for a call with 10 2, the code accesses 
2 3 4 5 6 7 8 9 10 11
where the last two indices are again out of bounds.


With the new code, for (10, 1) the indices accessed are
1 2 3 4      (1st loop)
5 6 7 8 9   (2nd loop)
and are all within bounds.

For the call (2, 10), the new indices are
2 3 4       (1st loop)
5 6 7 8 9  (2nd loop)